### PR TITLE
chore: move some cibw config to pyproject

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -45,15 +45,11 @@ jobs:
 
     - uses: pypa/cibuildwheel@v2.13.0
       env:
-        # Target 64 bit architectures (x86_64, and arm64 on macOS)
-        CIBW_ARCHS: auto64
+        # Cross-compile on macOS
         CIBW_ARCHS_MACOS: x86_64 arm64
 
         # Temporary: use pre-release Python 3.12 for stable API builds
         CIBW_PRERELEASE_PYTHONS: True
-
-        # GitHub Actions doesn't have macOS/arm64 runners, skip test on this platform
-        CIBW_TEST_SKIP "*-macosx_arm64"
 
     - name: Verify clean directory
       run: git diff --exit-code

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -10,28 +10,6 @@ on:
     types:
       - published
 
-env:
-  # Python 3.12+ is handled using the stable ABI, no need to build later versions
-  # Only build for PyPy 3.9
-  CIBW_SKIP: "pp37* pp38*"
-  # Target 64 bit architectures (x86_64, and arm64 on macOS)
-  CIBW_ARCHS_WINDOWS: auto64
-  CIBW_ARCHS_LINUX: auto64
-  CIBW_ARCHS_MACOS: x86_64 arm64
-  # Target older versions of macOS and Linux for good compatibility
-  CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.14
-  CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-  CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
-  # Necessary to see build output from the actual compilation
-  CIBW_BUILD_VERBOSITY: 1
-  # Temporary: use pre-release Python 3.12 for stable API builds
-  CIBW_PRERELEASE_PYTHONS: True
-  # GitHub Actions doesn't have macOS/arm64 runners, skip test on this platform
-  CIBW_TEST_SKIP: "*-macosx_arm64"
-  # Run pytest to ensure that the package was correctly built
-  CIBW_TEST_COMMAND: pytest {project}/tests
-  CIBW_TEST_REQUIRES: pytest
-
 jobs:
   build_sdist:
     name: Build SDist
@@ -66,6 +44,16 @@ jobs:
         submodules: true
 
     - uses: pypa/cibuildwheel@v2.13.0
+      env:
+        # Target 64 bit architectures (x86_64, and arm64 on macOS)
+        CIBW_ARCHS: auto64
+        CIBW_ARCHS_MACOS: x86_64 arm64
+
+        # Temporary: use pre-release Python 3.12 for stable API builds
+        CIBW_PRERELEASE_PYTHONS: True
+
+        # GitHub Actions doesn't have macOS/arm64 runners, skip test on this platform
+        CIBW_TEST_SKIP "*-macosx_arm64"
 
     - name: Verify clean directory
       run: git diff --exit-code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ wheel.py-api = "cp312"
 
 
 [tool.cibuildwheel]
-# PyPy37 is no longer supported by PyPy, PyPy38 is not supported by nanobind
-skip = ["pp37*", "pp38*"]
+# PyPy38 is not supported by nanobind
+skip = ["pp38*"]
 
 # 32-bit builds are not supported by nanobind
 archs = ["auto64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ wheel.py-api = "cp312"
 
 
 [tool.cibuildwheel]
-# PyPy37 is no longer supported by PyPy
-skip = ["pp37*"]
+# PyPy37 is no longer supported by PyPy, PyPy38 is not supported by nanobind
+skip = ["pp37*", "pp38*"]
 
 # 32-bit builds are not supported by nanobind
 archs = ["auto64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,13 @@ Homepage = "https://github.com/wjakob/nanobind_example"
 # Build stable ABI wheels for CPython 3.12+
 wheel.py-api = "cp312"
 
+
 [tool.cibuildwheel]
-# Only build for PyPy 3.9
-skip = ["pp37*", "pp38*"]
+# PyPy37 is no longer supported by PyPy
+skip = ["pp37*"]
+
+# 32-bit builds are not supported by nanobind
+archs = ["auto64"]
 
 # Necessary to see build output from the actual compilation
 build-verbosity = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,19 @@ Homepage = "https://github.com/wjakob/nanobind_example"
 [tool.scikit-build]
 # Build stable ABI wheels for CPython 3.12+
 wheel.py-api = "cp312"
+
+[tool.cibuildwheel]
+# Only build for PyPy 3.9
+skip = ["pp37*", "pp38*"]
+
+# Necessary to see build output from the actual compilation
+build-verbosity = 1
+
+# Run pytest to ensure that the package was correctly built
+test-command = "pytest {project}/tests"
+test-requires = "pytest"
+
+# Needed for full C++17 support
+[tool.cibuildwheel.macos.environment]
+MACOSX_DEPLOYMENT_TARGET = "10.14"
+


### PR DESCRIPTION
This moves some config to pyproject.toml to make it easier to run locally. I could move more or less. I also dropped the manylinux2014 lines as that is the default, and you generally set this for special cases when you need less compatibility (like `manylinux_2_28`, which is the only other _supported_ option).
