### PR TITLE
chore: enable build caching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if (NOT SKBUILD)
    $ pip install --no-build-isolation -ve .
   =====================================================================
   You can optionally add -Ceditable.rebuild=true to auto-rebuild when you
-  import.
+  import. Otherwise, you need to rerun the above command when you edit C++ files.
   ")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,12 @@ if (NOT SKBUILD)
   in your environment once and use the following command that avoids
   a costly creation of a new virtual environment at every compilation:
   =====================================================================
-   $ pip install --no-build-isolation -v .
-  =====================================================================")
+   $ pip install nanobind scikit-build-core[pyproject]
+   $ pip install --no-build-isolation -ve .
+  =====================================================================
+  You can optionally add -Ceditable.rebuild=true to auto-rebuild when you
+  import.
+  ")
 endif()
 
 # Try to import all Python components potentially needed by nanobind

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository contains a tiny project showing how to create C++ bindings
 using [nanobind](https://github.com/wjakob/nanobind) and
 [scikit-build-core](https://scikit-build-core.readthedocs.io/en/latest/index.html). It
 was derived from the corresponding _pybind11_ [example
-project](https://github.com/pybind/cmake_example/) developed by
+project](https://github.com/pybind/scikit_build_example/) developed by
 [@henryiii](https://github.com/henryiii).
 
 Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,12 @@ Homepage = "https://github.com/wjakob/nanobind_example"
 
 
 [tool.scikit-build]
+# Protect the configuration against future changes in scikit-build-core
+minimum-version = "0.4"
+
+# Setuptools-style build caching in a local directory
+build-dir = "build/{wheel_tag}"
+
 # Build stable ABI wheels for CPython 3.12+
 wheel.py-api = "cp312"
 


### PR DESCRIPTION
This causes cmake to set the build directory to `package/build/<wheel_tag>`, which gets reused if you build again. Moving paths due to build isolation will automatically be corrected by scikit-build-core.

If you want to go all out, try:

```bash
pip install nanobind scikit-build-core[pyproject]
pip install --no-build-isolation -Ceditable.rebuild=true -ve .
```

Then make a C++ change, then open Python and import the project. ;)
