### PR TITLE
add `__all__` to package file

### DIFF
--- a/src/nanobind_example/__init__.py
+++ b/src/nanobind_example/__init__.py
@@ -1,1 +1,3 @@
 from .nanobind_example_ext import add
+
+__all__ = ["add"]

--- a/src/nanobind_example/__init__.py
+++ b/src/nanobind_example/__init__.py
@@ -1,3 +1,3 @@
-from .nanobind_example_ext import add
+from .nanobind_example_ext import __doc__, __version__, add
 
-__all__ = ["add"]
+__all__ = ["__doc__", "__version__", "add"]


### PR DESCRIPTION
Populating the `__all__` attribute stops IDEs from complaining with messages like 
```
Cannot find reference 'add' in 'imported module nanobind_example | __init__.py'
```