### PR TITLE
Fix referenced ``gh-action-pypi-publish`` version in ``wheels.yml`` (#31)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -75,7 +75,7 @@ jobs:
         name: artifact
         path: dist
 
-    - uses: pypa/gh-action-pypi-publish@v1
+    - uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Thanks for creating this example project, it was incredibly helpful for adding nanobind support to some personal C++/python projects. However, in my projects, it seems like the last part of the wheels workflow that uploads artifacts to pypi wasn't working out of the box. I had to update from
 
`pypa/gh-action-pypi-publish@v1` which produces this error message

<img width="1039" alt="Screenshot 2023-07-09 at 8 07 22 AM" src="https://github.com/wjakob/nanobind_example/assets/16393433/e0d7806a-aad7-4985-a9e6-b00dfeaf3356">

to `pypa/gh-action-pypi-publish@release/v1` to get things working.