### PR TITLE
Update `gh-action-pypi-publish` version format

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -75,7 +75,7 @@ jobs:
         name: artifact
         path: dist
 
-    - uses: pypa/gh-action-pypi-publish@v1
+    - uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Update version of `pypa/gh-action-pypi-publish` according to [Readme](https://github.com/pypa/gh-action-pypi-publish/blob/413a8d5d62d32e541601a504492b8d5c5501a001/README.md?plain=1#L17-L21).