### PR TITLE
fix: classifier invalid

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     { name = "Wenzel Jakob", email = "wenzel.jakob@epfl.ch" },
 ]
 classifiers = [
-    "License :: BSD",
+    "License :: OSI Approved :: BSD License",
 ]
 
 [project.urls]


### PR DESCRIPTION
Classifier must be a valid classifier to upload.

Noticed when adding `validate-pyproject` support to scikit-build.