### PR TITLE
Show show to set .doc() in extension

### DIFF
--- a/src/nanobind_example/__init__.py
+++ b/src/nanobind_example/__init__.py
@@ -1,2 +1,1 @@
-from .nanobind_example_ext import add
-from .nanobind_example_ext import __doc__
+from .nanobind_example_ext import add, __doc__

--- a/src/nanobind_example/__init__.py
+++ b/src/nanobind_example/__init__.py
@@ -1,1 +1,2 @@
 from .nanobind_example_ext import add
+from .nanobind_example_ext import __doc__

--- a/src/nanobind_example_ext.cpp
+++ b/src/nanobind_example_ext.cpp
@@ -5,5 +5,6 @@ namespace nb = nanobind;
 using namespace nb::literals;
 
 NB_MODULE(nanobind_example_ext, m) {
+    m.doc() = "This is a \"hello world\" example with nanobind";
     m.def("add", [](int a, int b) { return a + b; }, "a"_a, "b"_a);
 }


### PR DESCRIPTION
and have that get pulled in properly into the ``help(nanobind_extension)``. After this PR is merged the help will look like:

<img width="569" alt="image" src="https://github.com/wjakob/nanobind_example/assets/11966765/8724344c-0d7a-45d2-b487-00f3877421b1">

See also https://github.com/wjakob/nanobind/issues/612