### PR TITLE
chore: use scikit-build-core 0.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core >=0.4.3", "nanobind >=1.3.2"]
+requires = ["scikit-build-core >=0.10", "nanobind >=1.3.2"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -21,7 +21,7 @@ Homepage = "https://github.com/wjakob/nanobind_example"
 
 [tool.scikit-build]
 # Protect the configuration against future changes in scikit-build-core
-minimum-version = "0.4"
+minimum-version = "build-system.requires"
 
 # Setuptools-style build caching in a local directory
 build-dir = "build/{wheel_tag}"


### PR DESCRIPTION
This minimum can now be single-sourced.