### PR TITLE
ci: fix broken configuration

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -27,11 +27,12 @@ jobs:
     - name: Set min macOS version
       if: runner.os == 'macOS'
       run: |
-        echo "MACOS_DEPLOYMENT_TARGET=10.14" >> $GITHUB_ENV
+        echo "MACOSX_DEPLOYMENT_TARGET=10.14" >> $GITHUB_ENV
 
     - name: Build and install
-      run: python -m pip install pytest
-           pip install --verbose .
+      run: |
+        python -m pip install pytest
+        pip install --verbose .
 
     - name: Test
       run: python -m pytest


### PR DESCRIPTION
I'm not sure how this ever passed, but:

```yaml
      run: python -m pip install pytest
           pip install --verbose .
```

is exactly the same as

```yaml
      run: python -m pip install pytest pip install --verbose .
```

in YAML. If you used a YAML formatter, say in pre-commit, it would have rewritten this for you and it would have been obvious that it was incorrect. Currently it's failing because there is no `install` package, maybe there used to be such a package and it got removed?

This should fix #51 and #52.