### PR TITLE
Improve some aspects of the wheel building + publishing job

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -56,29 +56,19 @@ jobs:
         path: wheelhouse/*.whl
         name: dist-${{ matrix.os }}
 
-  merge_wheels:
-    name: Merge wheels into a combined artifact
-    runs-on: ubuntu-latest
-    needs: [build_wheels, build_sdist]
-    steps:
-      - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
-        with:
-          name: dist
-          pattern: dist-*
-
   upload_all:
     name: Upload if release
-    needs: merge_wheels
+    needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
     - uses: actions/setup-python@v5
-
     - uses: actions/download-artifact@v4
       with:
-        path: dist
+        name: dist
+        pattern: dist-*
+        merge-multiple: true
 
     - uses: pypa/gh-action-pypi-publish@release/v1
       with:


### PR DESCRIPTION
* `macos-12` is removed from GitHub Actions as of today, bump to `macos-13`.
* The `download-artifact@v4` action can merge a collection of artifacts given by glob, using the `merge-multiple` option. This is in line with the cibuildwheel documentation in https://cibuildwheel.pypa.io/en/stable/deliver-to-pypi/#github-actions.