### PR TITLE
Add note about setuptools branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ project](https://github.com/pybind/scikit_build_example/) developed by
 Furthermore, the [bazel](https://github.com/wjakob/nanobind_example/tree/bazel) branch contains an example
 on how to build nanobind bindings extensions with Bazel using the [nanobind-bazel](https://github.com/nicholasjng/nanobind-bazel/) project.
 
+Similarly, the [setuptools](https://github.com/wjakob/nanobind_example/tree/setuptools) branch contains a recipe for
+building nanobind extensions with [setuptools](https://setuptools.pypa.io/en/latest/), a popular Python packaging
+solution with support for C++ extensions.
+
 Installation
 ------------
 


### PR DESCRIPTION
Similar to the already existing note on the Bazel branch.

I pushed this to make my findings on setuptools-powered nanobind extension builds available to interested users. This is work in progress, but builds already on my machine, and follows the custom builds user guide in `nb_combined.cpp` on Linux.

----------------

Contains my research on a pybind11 migration project I'm doing on the side. If there is interest on your part, I can also write a small explanatory guide on setuptools for the nanobind docs. I'm aware that CMake is the preferred build system, but I figured that removing hurdles for getting users of other packaging solutions on board can be worth it.