### PR TITLE
wheels: Use `macos-15-intel` runner to avoid deprecations

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-15-intel, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub has deprecated the `macos-13` image, which will be removed in December of 2025. To avoid errors, upgrade to the `macos-15-intel` runner image for macOS x86 wheel builds.

--------------

Deprecation notice is at https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down.